### PR TITLE
Populate with GET request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -173,7 +173,7 @@ export default function App() {
                             />
                     </Container>
                 </div>
-                <div class="gcse-search"></div>
+                <div className="gcse-search"></div>
             </main>
         </React.Fragment>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -118,7 +118,7 @@ export default function App() {
      */
     function querySearch(inputValue, outputLanguageValue) {
       let query = inputValue + " in "
-      query += supportedLanguages[outputLanguageValue] // get pretty name
+      query += supportedLanguages[outputLanguageValue]["name"] // get pretty name
 
       document.getElementById("gsc-i-id1").value = query;
       const buttons = document.getElementsByClassName("gsc-search-button gsc-search-button-v2")
@@ -133,6 +133,7 @@ export default function App() {
     const handleOutputLanguageChange = (event, value) => {
         setOutputLanguage(value)
         postRequest(input, inputLanguage, value)
+        querySearch(input, value)
     } 
 
     const handleInputChange = (event) => {

--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ function allowTabs() {
 }
 
 export default function App() {
-  const BACKEND_URL = `https://cjsbackdev.herokuapp.com/`
+  const BACKEND_URL = `https://cjsback.herokuapp.com/`
   const classes = useStyles();
 
     // set state

--- a/src/App.js
+++ b/src/App.js
@@ -69,9 +69,8 @@ export default function App() {
         setSupportedLanguages(data["supported_languages"]);
     }
 
-    // deals with the fact that setting state is asynchronous
     useEffect(() => {
-        getRequest() // send get request immediately to ping backend so it wakes up
+        getRequest() // send get request immediately to ping backend and populate frontend
         
         const script = document.createElement('script');
 

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
   box: {
     padding: theme.spacing(2),
     height: "100%",
-  }
+  },
 }));
 
 // TODO: Use refs instead of this method
@@ -52,7 +52,8 @@ function allowTabs() {
 }
 
 export default function App() {
-    const classes = useStyles();
+  const BACKEND_URL = `https://cjsbackdev.herokuapp.com/`
+  const classes = useStyles();
 
     // set state
     const [timer, setTimer] = useState(null);
@@ -60,14 +61,17 @@ export default function App() {
     const [output, setOutput] = useState("");
     const [inputLanguage, setInputLanguage] = useState("js");
     const [outputLanguage, setOutputLanguage] = useState("py");
+    const [supportedLanguages, setSupportedLanguages] = useState([]);
 
-    async function wakeUpServer() {
-        fetch(`https://cjsback.herokuapp.com/`)
+    async function getRequest() {
+        const res = await fetch(BACKEND_URL);
+        const data = await res.json();
+        setSupportedLanguages(data["supported_languages"]);
     }
 
     // deals with the fact that setting state is asynchronous
     useEffect(() => {
-        wakeUpServer() // send get request immediately to ping backend so it wakes up
+        getRequest() // send get request immediately to ping backend so it wakes up
         
         const script = document.createElement('script');
 
@@ -92,11 +96,12 @@ export default function App() {
         const requestOptions = {
           method: 'POST',
           headers: new Headers({
+            
               'Content-Type': 'application/x-www-form-urlencoded',
           }),
           body: params.toString()
         };
-        const response = await fetch('https://cjsback.herokuapp.com/', requestOptions);    
+        const response = await fetch(BACKEND_URL, requestOptions);    
         const translation = await response.json();
         
         // change in_lang only if it is defined
@@ -113,12 +118,7 @@ export default function App() {
      */
     function querySearch(inputValue, outputLanguageValue) {
       let query = inputValue + " in "
-      if (outputLanguageValue === "js") { // FIXME: this should eventually come from backend
-        query += "javascript";
-      }
-      if (outputLanguageValue === "py") {
-        query += "python";
-      }
+      query += supportedLanguages[outputLanguageValue] // get pretty name
 
       document.getElementById("gsc-i-id1").value = query;
       const buttons = document.getElementsByClassName("gsc-search-button gsc-search-button-v2")
@@ -155,13 +155,15 @@ export default function App() {
                 {/* Hero unit */}
                 <div className={classes.heroContent}>
                     <Container maxWidth="md">
-                            <LanguageBar 
-                              inputLanguage={inputLanguage} 
-                              outputLanguage={outputLanguage} 
-                              handleInputLanguageChange= {handleInputLanguageChange} 
-                              handleOutputLanguageChange= {handleOutputLanguageChange} 
-                              classes={classes}
-                            />
+                            { Object.keys(supportedLanguages).length > 0 &&
+                              <LanguageBar 
+                                supportedLanguages = {supportedLanguages}
+                                inputLanguage={inputLanguage} 
+                                outputLanguage={outputLanguage} 
+                                handleInputLanguageChange= {handleInputLanguageChange} 
+                                handleOutputLanguageChange= {handleOutputLanguageChange} 
+                                classes={classes}
+                            />}
                             <TranslateBoxes
                               input= {input}
                               handleInputChange={handleInputChange}

--- a/src/components/LanguageBar.js
+++ b/src/components/LanguageBar.js
@@ -35,14 +35,6 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
                             <Tab key={code} value={code} label={supportedLanguages[code]["name"]} />
                         ))}
                     </Tabs>
-                    {/* <Tabs
-                        value={inputLanguage}
-                        onChange={handleInputLanguageChange}
-                        indicatorColor="primary"
-                        textColor="primary"
-                        variant="fullWidth"
-                    > */}
-                    {/* </Tabs> */}
                 </Grid>
                 {/* TODO: break up both sets of tabs */}
                 <Grid item xs={6}>
@@ -58,7 +50,6 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
                             <Tab key={code} value={code} label={supportedLanguages[code]["name"]} />
                         ))}
                     </Tabs>
-
                 </Grid>
             </Grid>
         </AppBar>

--- a/src/components/LanguageBar.js
+++ b/src/components/LanguageBar.js
@@ -36,7 +36,6 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
                         ))}
                     </Tabs>
                 </Grid>
-                {/* TODO: break up both sets of tabs */}
                 <Grid item xs={6}>
                     <Tabs 
                       value={outputLanguage} 

--- a/src/components/LanguageBar.js
+++ b/src/components/LanguageBar.js
@@ -5,34 +5,49 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
 
-export default function LanguageBar({inputLanguage, outputLanguage, handleInputLanguageChange, handleOutputLanguageChange, classes}) {
+export default function LanguageBar({supportedLanguages, inputLanguage, outputLanguage, handleInputLanguageChange, handleOutputLanguageChange, classes}) {
+    const langCodes = Object.keys(supportedLanguages);
+    
     return(
-        <AppBar position="static" className={classes.languageBar}>
+        <AppBar position="static" color="default">
             <Grid container className={classes.basicGrid} spacing={2}>
                 <Grid item xs={6}>
-                    <Tabs
+                    <Tabs 
+                      value={inputLanguage} 
+                      onChange={handleInputLanguageChange} 
+                      indicatorColor="primary" 
+                      textColor="primary" 
+                      variant="scrollable" 
+                      scrollButtons="auto"
+                    >
+                        {langCodes.map( code => (
+                            <Tab key={code} value={code} label={supportedLanguages[code]} />
+                        ))}
+                    </Tabs>
+                    {/* <Tabs
                         value={inputLanguage}
                         onChange={handleInputLanguageChange}
                         indicatorColor="primary"
                         textColor="primary"
                         variant="fullWidth"
-                    >
-                        <Tab value= "js" label="JavaScript" />
-                        <Tab value="py" label="Python" />
-                    </Tabs>
+                    > */}
+                    {/* </Tabs> */}
                 </Grid>
                 {/* TODO: break up both sets of tabs */}
                 <Grid item xs={6}>
-                    <Tabs
-                        value={outputLanguage}
-                        onChange={handleOutputLanguageChange}
-                        indicatorColor="primary"
-                        textColor="primary"
-                        variant="fullWidth"
+                    <Tabs 
+                      value={outputLanguage} 
+                      onChange={handleOutputLanguageChange} 
+                      indicatorColor="primary" 
+                      textColor="primary" 
+                      variant="scrollable" 
+                      scrollButtons="auto"
                     >
-                        <Tab value= "js" label="JavaScript" />
-                        <Tab value="py" label="Python" />
+                        {langCodes.map( code => (
+                            <Tab key={code} value={code} label={supportedLanguages[code]} />
+                        ))}
                     </Tabs>
+
                 </Grid>
             </Grid>
         </AppBar>

--- a/src/components/LanguageBar.js
+++ b/src/components/LanguageBar.js
@@ -6,7 +6,18 @@ import Tab from '@material-ui/core/Tab';
 
 
 export default function LanguageBar({supportedLanguages, inputLanguage, outputLanguage, handleInputLanguageChange, handleOutputLanguageChange, classes}) {
-    const langCodes = Object.keys(supportedLanguages);
+
+    // Get input and output language codes
+    const inputLangCodes = []
+    const outputLangCodes = []
+    for (const code in supportedLanguages){
+        if (supportedLanguages[code]["is_input_lang"]){
+            inputLangCodes.push(code);
+        }
+        if (supportedLanguages[code]["is_output_lang"]){
+            outputLangCodes.push(code);
+        }
+    }
     
     return(
         <AppBar position="static" color="default">
@@ -20,8 +31,8 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
                       variant="scrollable" 
                       scrollButtons="auto"
                     >
-                        {langCodes.map( code => (
-                            <Tab key={code} value={code} label={supportedLanguages[code]} />
+                        {inputLangCodes.map( code => (
+                            <Tab key={code} value={code} label={supportedLanguages[code]["name"]} />
                         ))}
                     </Tabs>
                     {/* <Tabs
@@ -43,8 +54,8 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
                       variant="scrollable" 
                       scrollButtons="auto"
                     >
-                        {langCodes.map( code => (
-                            <Tab key={code} value={code} label={supportedLanguages[code]} />
+                        {outputLangCodes.map( code => (
+                            <Tab key={code} value={code} label={supportedLanguages[code]["name"]} />
                         ))}
                     </Tabs>
 


### PR DESCRIPTION
In an effort to increase modularity of the CodeTranslate tool, this PR now populates all of the input and output language information by fetching it from the backend. After this PR, new languages can be added without making any changes to the frontend. Developers simply add the language directory (containing translation files) to the backend and write one line in the backend bootstrap file.

This PR is closely related to the following two backend PR's:
- [GET request for Frontend](https://github.com/jackdavidweber/cjs_capstone/pull/81)
- [Add and make accessible more information about each converter](https://github.com/jackdavidweber/cjs_capstone/pull/92)

This is also the first PR where bash and java are displayed on the frontend. **Check out the demo [here](https://streamable.com/3upvbl)!**
![Screen Shot 2020-07-17 at 5 25 59 PM](https://user-images.githubusercontent.com/19896216/87840379-45ad1300-c854-11ea-8d49-49a02b98026d.png)
