### PR TITLE
Add session id to post request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,7 @@ export default function App() {
         const data = await res.json();
         setSupportedLanguages(data["supported_languages"]);
         setLoading(false);
+        sessionStorage.setItem('id', Date.now());
     }
 
     useEffect(() => {
@@ -99,11 +100,12 @@ export default function App() {
 
     }, [])
 
-    async function postRequest(inputValue, inputLanguageValue, outputLanguageValue ){
+    async function postRequest(inputValue, inputLanguageValue, outputLanguageValue ){ 
         const params = new URLSearchParams({
           input: inputValue,
           in_lang: inputLanguageValue,
-          out_lang: outputLanguageValue
+          out_lang: outputLanguageValue,
+          id: sessionStorage.getItem('id')
         })
 
         const requestOptions = {

--- a/src/App.js
+++ b/src/App.js
@@ -81,7 +81,10 @@ export default function App() {
         const data = await res.json();
         setSupportedLanguages(data["supported_languages"]);
         setLoading(false);
-        sessionStorage.setItem('id', Date.now());
+        if (sessionStorage.getItem('id') == null) {
+          sessionStorage.setItem('id', Date.now());
+        }
+        
     }
 
     useEffect(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -82,7 +82,7 @@ export default function App() {
         setSupportedLanguages(data["supported_languages"]);
         setLoading(false);
         if (sessionStorage.getItem('id') == null) {
-          sessionStorage.setItem('id', Date.now());
+          sessionStorage.setItem('id', uuidv4());
         }
         
     }
@@ -150,6 +150,14 @@ export default function App() {
         const buttons = document.getElementsByClassName("gsc-search-button gsc-search-button-v2")
         buttons[0].click();
       }
+    }
+    
+    // generates random GUID to use a session id
+    function uuidv4() {
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+      });
     }
 
     const handleInputLanguageChange = (event, value) => {


### PR DESCRIPTION
Add id to session storage using Date.now() which returns the number of milliseconds since Jan 1, 1970. Every time the page loads a user gets this as their id. It is then put as a param to the post request where it will be used to organize analytics.