### PR TITLE
Make output text black

### DIFF
--- a/src/components/TranslateBoxes.js
+++ b/src/components/TranslateBoxes.js
@@ -32,9 +32,8 @@ export default function TranslateBoxes({input, handleInputChange, output, classe
                         label="Translation"
                         multiline
                         fullWidth
-                        // TODO: create more contrast in output text font color
                         InputProps={{
-                            style: {fontFamily: "monospace"},
+                            style: {fontFamily: "monospace", color: "black"},
                             disableUnderline: true
                         }}
                         value={output}


### PR DESCRIPTION
Change color of output text color darker to improve contrast. 

Before:
<img width="918" alt="Screen Shot 2020-07-24 at 12 28 52 PM" src="https://user-images.githubusercontent.com/20179968/88413477-3d4f5d80-cda9-11ea-8df7-e1bf60f86769.png">

After:
<img width="923" alt="Screen Shot 2020-07-24 at 12 28 09 PM" src="https://user-images.githubusercontent.com/20179968/88413411-24df4300-cda9-11ea-85fa-a4cb4f723ba4.png">
