### PR TITLE
Intelligent Errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,7 @@ function allowTabs() {
 
 export default function App() {
   // TODO change back to not dev
-  const BACKEND_URL = `https://cjsback.herokuapp.com/`
+  const BACKEND_URL = `https://cjsbackdev.herokuapp.com/`
   const classes = useStyles();
 
     // set state
@@ -116,6 +116,7 @@ export default function App() {
         };
         const response = await fetch(BACKEND_URL, requestOptions);    
         const translation = await response.json();
+        console.log(translation)
         // change in_lang only if it is defined
         if (translation['response_in_lang'] !== "undefined"){
           if (inputLanguageValue === "auto") {

--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,7 @@ function allowTabs() {
 
 export default function App() {
   // TODO change back to not dev
-  const BACKEND_URL = `https://cjsbackdev.herokuapp.com/`
+  const BACKEND_URL = `https://cjsback.herokuapp.com/`
   const classes = useStyles();
 
     // set state

--- a/src/App.js
+++ b/src/App.js
@@ -70,6 +70,7 @@ export default function App() {
     const [timer, setTimer] = useState(null);
     const [input, setInput] = useState("");
     const [output, setOutput] = useState("");
+    const [errors, setErrors] = useState({})
     const [inputLanguage, setInputLanguage] = useState("auto");
     const [outputLanguage, setOutputLanguage] = useState("py");
     const [supportedLanguages, setSupportedLanguages] = useState([]);
@@ -116,7 +117,6 @@ export default function App() {
         };
         const response = await fetch(BACKEND_URL, requestOptions);    
         const translation = await response.json();
-        console.log(translation)
         // change in_lang only if it is defined
         if (translation['response_in_lang'] !== "undefined"){
           if (inputLanguageValue === "auto") {
@@ -128,7 +128,8 @@ export default function App() {
             setLanguageDetected("")
           }
         }
-
+        
+        setErrors(translation["error"])
         setOutput(translation["response"])
     }
 
@@ -201,6 +202,7 @@ export default function App() {
                       input= {input}
                       handleInputChange={handleInputChange}
                       output={output}
+                      errors={errors}
                       classes={classes}
                     />
             </Container>

--- a/src/components/LanguageBar.js
+++ b/src/components/LanguageBar.js
@@ -23,7 +23,6 @@ export default function LanguageBar({supportedLanguages, inputLanguage, outputLa
 
     function getLabel(code) {
         if (code === "auto") {
-            console.log(languageDetected)
             if (languageDetected !== "" && languageDetected !== "auto") {
                 return supportedLanguages[languageDetected]["name"] + " - detected"
             }

--- a/src/components/TranslateBoxes.js
+++ b/src/components/TranslateBoxes.js
@@ -12,7 +12,6 @@ export default function TranslateBoxes({input, handleInputChange, output, errors
 
             // go through output text and find any strings with pattern $$E_$$
             const regexp = /\$\$E.\$\$/g
-
             const matches = [...output.matchAll(regexp)];
 
             for (const match of matches){
@@ -58,7 +57,7 @@ export default function TranslateBoxes({input, handleInputChange, output, errors
                             style: {fontFamily: "monospace"},
                             disableUnderline: true
                         }}
-                        value={addErrorsToOutput(output, errors)}
+                        value={output && errors && addErrorsToOutput(output, errors)}
                         disabled
                         />
                     </Box>

--- a/src/components/TranslateBoxes.js
+++ b/src/components/TranslateBoxes.js
@@ -5,7 +5,28 @@ import TextField from '@material-ui/core/TextField';
 import Box from '@material-ui/core/Box';
 
 
-export default function TranslateBoxes({input, handleInputChange, output, classes}){
+export default function TranslateBoxes({input, handleInputChange, output, errors, classes}){
+    function addErrorsToOutput(output, errors){
+        if (Object.entries(errors).length !== 0){
+            let finalOutput = output
+
+            // go through output text and find any strings with pattern $$E_$$
+            const regexp = /\$\$E.\$\$/g
+
+            const matches = [...output.matchAll(regexp)];
+
+            for (const match of matches){
+                const errorKey = match[0].substring(2).slice(0,-2)
+                const errorMessage = errors[errorKey]["errorMessage"]
+                finalOutput = finalOutput.replace(match, errorMessage)
+            }
+            return finalOutput
+
+        } else {
+            return output
+        }
+    }
+
     return(
         <Paper className={classes.paper}>
             <Grid container className={classes.basicGrid} spacing={0}>
@@ -37,7 +58,7 @@ export default function TranslateBoxes({input, handleInputChange, output, classe
                             style: {fontFamily: "monospace"},
                             disableUnderline: true
                         }}
-                        value={output}
+                        value={addErrorsToOutput(output, errors)}
                         disabled
                         />
                     </Box>

--- a/src/components/TranslateBoxes.js
+++ b/src/components/TranslateBoxes.js
@@ -7,7 +7,7 @@ import Box from '@material-ui/core/Box';
 
 export default function TranslateBoxes({input, handleInputChange, output, errors, classes}){
     function addErrorsToOutput(output, errors){
-        if (Object.entries(errors).length !== 0){
+        if (errors && Object.entries(errors).length !== 0){
             let finalOutput = output
 
             // go through output text and find any strings with pattern $$E_$$
@@ -57,7 +57,7 @@ export default function TranslateBoxes({input, handleInputChange, output, errors
                             style: {fontFamily: "monospace"},
                             disableUnderline: true
                         }}
-                        value={output && errors && addErrorsToOutput(output, errors)}
+                        value={output && addErrorsToOutput(output, errors)}
                         disabled
                         />
                     </Box>

--- a/src/components/TranslateBoxes.js
+++ b/src/components/TranslateBoxes.js
@@ -57,7 +57,7 @@ export default function TranslateBoxes({input, handleInputChange, output, errors
                             style: {fontFamily: "monospace"},
                             disableUnderline: true
                         }}
-                        value={output && addErrorsToOutput(output, errors)}
+                        value={errors && output && addErrorsToOutput(output, errors)}
                         disabled
                         />
                     </Box>


### PR DESCRIPTION
With the overhaul of the backend error handling, the next step was to modify the frontend. The translation coming from the backend now includes error strings. The following are examples of translations now generated by backend where input is on left side and output is on right side (python --> bash):

1. `print([[1]])\n3**2` --> `echo $$E0$$\n$$E1$$`
2. `]x` --> `$$E0$$`

This of course is not what we want to display on the frontend. This is why associated with each error string is an error node in our error object that gives more information about the error. The error string is replaced by information from the error node:

1. `print([[1]])\n3**2` --> `echo direct translation does not exist\nfeature not supported`
2. `]x` --> `input code does not compile`

In the future rather than just replacing the text of the error string, we will incorporate a [tooltip](https://material-ui.com/components/tooltips/) describing the error as well as well as highlighting
